### PR TITLE
Apply transparent background and border to close button in body, as well as in header

### DIFF
--- a/src/BootstrapToast.svelte
+++ b/src/BootstrapToast.svelte
@@ -362,6 +362,10 @@
     border-top-left-radius: calc(0.25rem - 1px);
     border-top-right-radius: calc(0.25rem - 1px);
   }
+  .st-toast-close-btn {
+    background: transparent;
+    border: 0;
+  }
   .st-toast-header .st-toast-title {
     flex: 1;
     text-align: left;
@@ -371,8 +375,6 @@
   .st-toast-header .st-toast-close-btn {
     margin-right: -0.375rem;
     margin-left: 0.75rem;
-    background: transparent;
-    border: 0;
   }
   .st-toast-body {
     position: relative;


### PR DESCRIPTION
The close button in BootstrapToast looked like a default button when it was in the toast body.

```
 _____________________________________
|                                ___  |
| Message body (No title)       | x | |
|                                ---  |
|_____________________________________|
```
Now we have this
```
 _____________________________________
|                                     |
| Message body (No title)         x   |
|                                     |
|_____________________________________|
```
I just moved the background and border styles into a top-level `.st-toast-close-btn` selector, instead of a nested one `.st-toast-header .st-toast-close-btn`